### PR TITLE
updates for elixir 1.6 or higher

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DataCrypter.Mixfile do
   def project do
     [app: :data_crypter,
      version: "0.1.0",
-     elixir: "~> 1.3",
+     elixir: "~> 1.6",
      description: "AES 128/256 GCM encrypt/decrypt wrapper for Elixir.",
      package: package(),
      build_embedded: Mix.env == :prod,
@@ -29,8 +29,8 @@ defmodule DataCrypter.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:ex_doc, "~> 0.10", only: :dev},
-     {:credo, "~> 0.4", only: [:dev, :test]}]
+    [{:ex_doc, "~> 0.18.0", only: :dev, runtime: false},
+     {:credo, "~> 0.10.0", only: [:dev, :test], runtime: false}]
   end
 
   defp package do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DataCrypter.Mixfile do
   def project do
     [app: :data_crypter,
      version: "0.1.0",
-     elixir: "~> 1.6",
+     elixir: "~> 1.3",
      description: "AES 128/256 GCM encrypt/decrypt wrapper for Elixir.",
      package: package(),
      build_embedded: Mix.env == :prod,

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,10 @@
-%{"bunt": {:hex, :bunt, "0.1.6", "5d95a6882f73f3b9969fdfd1953798046664e6f77ec4e486e6fafc7caad97c6f", [:mix], []},
-  "credo": {:hex, :credo, "0.4.13", "0e9d0479c7e0591e36b093bf17fbdde012e2a69b5571e2df8d0b75b4fc8adc74", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
-  "earmark": {:hex, :earmark, "1.0.2", "a0b0904d74ecc14da8bd2e6e0248e1a409a2bc91aade75fcf428125603de3853", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.10.0", "66234a95effaf9067edb19fc5d0cd5c6b461ad841baac42467afed96c78e5e9e", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
+}

--- a/test/data_crypter_test.exs
+++ b/test/data_crypter_test.exs
@@ -22,22 +22,22 @@ defmodule DataCrypterTest do
   end
 
   test "#encrypt 256bit key" do
-    {_iv, ciphertext, _ciphertag} = DataCrypter.encrypt(key, aad, plaintext_data)
-    assert ciphertext != plaintext_data
+    {_iv, ciphertext, _ciphertag} = DataCrypter.encrypt(key(), aad(), plaintext_data())
+    assert ciphertext != plaintext_data()
   end
 
   test "#encrypt 128bit key" do
     key_128 = DataCrypter.generate_key(16)
-    {_iv, ciphertext, _ciphertag} = DataCrypter.encrypt(key_128, aad, plaintext_data)
-    assert ciphertext != plaintext_data
+    {_iv, ciphertext, _ciphertag} = DataCrypter.encrypt(key_128, aad(), plaintext_data())
+    assert ciphertext != plaintext_data()
   end
 
   test "Invalid key size at #encrypt" do
     assert_raise ArgumentError, "Invalit key size", fn ->
-      DataCrypter.encrypt("Too short key", aad, plaintext_data)
+      DataCrypter.encrypt("Too short key", aad(), plaintext_data())
     end
     assert_raise ArgumentError, "Invalit key size", fn ->
-      DataCrypter.encrypt("Too loooooooooooooooooooooong key", aad, plaintext_data)
+      DataCrypter.encrypt("Too loooooooooooooooooooooong key", aad(), plaintext_data())
     end
   end
 
@@ -57,11 +57,11 @@ defmodule DataCrypterTest do
     end
 
     test "#decrypt" do
-      assert plaintext_data == DataCrypter.decrypt(key, aad, iv, ciphertext, ciphertag)
+      assert plaintext_data() == DataCrypter.decrypt(key(), aad(), iv(), ciphertext(), ciphertag())
     end
 
     test "Invalid add data" do
-      assert :error == DataCrypter.decrypt(key, "Invalid add", iv, ciphertext, ciphertag)
+      assert :error == DataCrypter.decrypt(key(), "Invalid add", iv(), ciphertext(), ciphertag())
     end
   end
 end


### PR DESCRIPTION
### Changes

* <del> bumps up elixir version to 1.6 </del>
* update `ex_doc` and `credo` 
* fix warnings in tests (fortunately no warnings in library code 👍 )

locally tested with elixir version 1.6.6
